### PR TITLE
Be specific when using word "șir" (Romanian)

### DIFF
--- a/book/chapters/04-process/contents.tex
+++ b/book/chapters/04-process/contents.tex
@@ -1516,8 +1516,8 @@ din sistem la un moment de timp).
 Unul dintre cele mai importante tipuri de procese interactive dintr-un sistem
 este \textbf{shellul}, adică procesul ce primește intrare de la utilizator și comandă
 apoi sistemul de operare sau alte procese. Un shell poate fi grafic sau în linia de comandă. Un
-shell în linia de comandă (numit interpretor de comenzi) va primi un șir de la
-intrare de la utilizator, va interpreta acel șir într-o comandă (sau mai multe
+shell în linia de comandă (numit interpretor de comenzi) va primi un șir de caractere de la
+intrare de la utilizator, va interpreta acel șir de caractere într-o comandă (sau mai multe
 comenzi înlănțuite) și va crea un proces sau mai multe procese. Vom detalia
 funcționarea shellului în \labelindexref{Capitolul}{chapter:cli}.
 

--- a/book/chapters/07-cli/contents.tex
+++ b/book/chapters/07-cli/contents.tex
@@ -699,7 +699,7 @@ Expandarea de acolade înseamnă trecerea prin mai multe opțiuni.
   \item Liniile \texttt{14-19} prezintă expandarea unei variabile, caz de expandare parametrică. În cazul simplu se folosește doar caracterul \texttt{\$} (\textit{dollar}). Altfel folosim construcții care încep cu \texttt{\$\{} (dolar-acoladă), ca să fie clar care este numele variabile.
     De exemplu, linia \texttt{16} va încerca afișarea valorii variabilei \texttt{config\_test}, nu a valorii variabilei \texttt{config} urmată de
     șirul \texttt{\_test}. Pentru aceasta o rulare corectă este cea de la linia \texttt{18}.
-  \item Liniile \texttt{21-24} prezintă expandarea aritmetică. Dacă nu am folosi construcția \verb|$((...))| pentru expandare aritmetică, nu s-ar realiza calculul matematic, ci doar s-ar afișa expresia în cauză, ca un șir.
+  \item Liniile \texttt{21-24} prezintă expandarea aritmetică. Dacă nu am folosi construcția \verb|$((...))| pentru expandare aritmetică, nu s-ar realiza calculul matematic, ci doar s-ar afișa expresia în cauză, ca un șir de caractere.
 \end{itemize}
 
 \begin{screen}[caption={Forme de expandare în shell},label={lst:cli:expansion}]
@@ -872,7 +872,7 @@ student@uso:~/uso.git$ ls USO\ -\ Curs\ 07.pdf
 'USO - Curs 07.pdf'
 \end{screen}
 
-Fiecare formă poate fi la rândul său folosită pentru a escapa celelalte forme, așa cum apare în \labelindexref{Listing}{lst:cli:escaping-create}. Este similar cu escapingul ghilimelelor într-un șir dintr-un limbaj de programare (precum C sau Python)
+Fiecare formă poate fi la rândul său folosită pentru a escapa celelalte forme, așa cum apare în \labelindexref{Listing}{lst:cli:escaping-create}. Este similar cu escapingul ghilimelelor într-un șir de caractere dintr-un limbaj de programare (precum C sau Python)
 
 \begin{screen}[caption={Forme de escaping în shell},escapechar=,label={lst:cli:escaping-create}]
 student@uso:~/test$ touch "ana'are'mere"

--- a/book/chapters/09-boot/contents.tex
+++ b/book/chapters/09-boot/contents.tex
@@ -415,7 +415,7 @@ partiții extinse să creăm oricâte partiții logice.
 
 GPT (\textit{GUID Partition Table}) este o schemă modernă de partiționare pe PC. În
 cadrul acestei scheme de partiționare există 128 de partiții, identificate în
-mod unic, la nivel global printr-un șir numit GUID (\textit{global unique id}). Schema de
+mod unic, la nivel global printr-un șir de caractere numit GUID (\textit{global unique id}). Schema de
 partiționare GPT cuprinde 128 de partiții, eliminând limitarea de 4 partiții a
 schemei de partiționare MBR.
 
@@ -508,7 +508,7 @@ pe echivalentul celor de mai jos:
 Întrucât ordinea discurilor poate diferi prin mutarea discurilor sau prin
 adăugarea unui disc nou, cele două moduri de denumire de mai sus sunt variabile.
 Pentru a menține o denumire fixă, se folosește un identificator unic al
-partiției un șir numit UUID \abbrev{UUID}{Universally Unique Identifier}
+partiției un șir de caractere numit UUID \abbrev{UUID}{Universally Unique Identifier}
 (Universally Unique Identifier). Pe Linux putem obține acest identificator cu
 ajutorul comenzii \cmd{blkid} sau listând conținutul directorului \file{/dev/disk/by-uuid},
 ca în \labelindexref{Listing}{lst:boot:dev-name}.

--- a/book/chapters/13-auto/contents.tex
+++ b/book/chapters/13-auto/contents.tex
@@ -585,7 +585,7 @@ O listă completă găsiți în pagina de manual a comenzii \cmd{test}.
         verifică dacă primul parametru al scriptului are ca valoare șirul \texttt{/etc/passwd} \\
 
         \cmd{test -z "\$store"} &
-        verifică dacă variabila \texttt{store} nu conține nici o informație (este un șir vid) \\
+        verifică dacă variabila \texttt{store} nu conține nici o informație (este un șir de caractere vid) \\
 
         \cmd{test !\@ -z "\$store"} &  % \@ este necesar după !, altfel LaTeX consideră că se termină o frază și bugetează spațiu în plus.
         verifică opusul condiției de mai sus \\
@@ -631,8 +631,8 @@ Aceleași verificări realizate cu \cmd{test} și \cmd{$[$} pot fi realizate și
 Pe lângă acestea, \cmd{$[[$} permite verificări suplimentare, ca cele prezentate în \labelindexref{Listing}{lst:auto:shell-builtin-bracket}:
 \begin{itemize}
   \item liniile \texttt{1-2}: verificare de condiții compuse, folosind operatorul \texttt{\&\&} (ȘI logic - \textit{logical AND})
-  \item liniile \texttt{4-5}: comparația unui șir cu o construcție de tip pattern / globbing (prezentate în \labelindexref{Secțiunea}{sec:cli:shell-func:expansion:globbing}), folosind operatorul \texttt{==}
-  \item liniile \texttt{7-8}: comparația unui șir cu o construcție de tip expresie regulată (prezentate în \labelindexref{Secțiunea}{sec:cli:regex}), folosind operatorul \texttt{=$\sim$}
+  \item liniile \texttt{4-5}: comparația unui șir de caractere cu o construcție de tip pattern / globbing (prezentate în \labelindexref{Secțiunea}{sec:cli:shell-func:expansion:globbing}), folosind operatorul \texttt{==}
+  \item liniile \texttt{7-8}: comparația unui șir de caractere cu o construcție de tip expresie regulată (prezentate în \labelindexref{Secțiunea}{sec:cli:regex}), folosind operatorul \texttt{=$\sim$}
 \end{itemize}
 
 \begin{screen}[caption={Folosirea comenzii interne {[[}},label={lst:auto:shell-builtin-bracket}]
@@ -661,7 +661,7 @@ Sintaxa comenzii \cmd{case} este indicată în \labelindexref{Listing}{lst:auto:
 Valoarea variabilei \texttt{var} este comparată cu diferite patternuri, precum \texttt{abc*} sau \texttt{*$[$de$]$fg*}.
 În cazul fiecărei potriviri, se execută comenzile corespunzătoare.
 De avut în vedere construcția \texttt{;;} pentru închiderea unei opțiuni \cmd{case}.
-Construcția \texttt{*} definește echivalentul etichetei \texttt{default} din programarea în C: se potrivește cu orice șir.
+Construcția \texttt{*} definește echivalentul etichetei \texttt{default} din programarea în C: se potrivește cu orice șir de caractere.
 În mod obișnuit, se plasează ca ultima opțiune pentru \cmd{case}, iar comenzile corespunzătoare sunt executate dacă nu s-au potrivit cu nici o altă opțiune.
 
 \begin{screen}[caption={Sintaxa comenzii case},label={lst:auto:case-syntax}]


### PR DESCRIPTION
Use "șir de caractere" to make it more precise.
This addresses issue #15.

Signed-off-by: Razvan Deaconescu <razvan.deaconescu@cs.pub.ro>