### PR TITLE
Move table captions below table

### DIFF
--- a/book/chapters/00-intro/contents.tex
+++ b/book/chapters/00-intro/contents.tex
@@ -207,7 +207,6 @@ Distribuțiile Linux pot fi clasificate în familii de distribuții. O familie a
 Descrieri și comparații între distribuții, argumente pentru a alege una găsiți în număr mare pe Internet și pe site-ul DistroWatch\footnote{\url{https://distrowatch.com/}}. Un sumar al celor mai cunoscute distribuții Linux sunt în \labelindexref{Tabelul}{tab:intro:distro}.
 
 \begin{table}[!htb]
-  \caption{Distribuții Linux}
   \begin{center}
     \begin{tabular}{ p{0.13\textwidth} p{0.28\textwidth} p{0.23\textwidth} p{0.25\textwidth} }
       \toprule
@@ -246,8 +245,9 @@ Descrieri și comparații între distribuții, argumente pentru a alege una găs
         continuu (rolling) \\
       \bottomrule
     \end{tabular}
-    \label{tab:intro:distro}
   \end{center}
+  \caption{Distribuții Linux}
+  \label{tab:intro:distro}
 \end{table}
 
 \subsection{Mașina virtuală de suport}

--- a/book/chapters/01-ui/contents.tex
+++ b/book/chapters/01-ui/contents.tex
@@ -205,7 +205,6 @@ Distribuțiile, mediile desktop, managerii de ferestre și aplicațiile Linux su
 Așa cum am precizat mai sus, pentru acțiuni rapide în interfața grafică a unui sistem de operare (și, în general, a unei aplicații) sunt utile scurtăturile de tastatură. \labelindexref{Tabelul}{tab:ui:vm-shortcuts} conține cele mai comune scurtături în mașina virtuală.
 
 \begin{table}[!htb]
-  \caption{Scurtături de tastatură în mașina virtuală de suport}
   {\scriptsize
   \begin{center}
     \begin{tabular}{ p{0.22\textwidth} p{0.3\textwidth} p{0.38\textwidth} }
@@ -299,9 +298,10 @@ Așa cum am precizat mai sus, pentru acțiuni rapide în interfața grafică a u
 
       \bottomrule
     \end{tabular}
-    \label{tab:ui:vm-shortcuts}
   \end{center}
   }
+  \caption{Scurtături de tastatură în mașina virtuală de suport}
+  \label{tab:ui:vm-shortcuts}
 \end{table}
 
 O scurtătură frecventă de tastatură, întâlnită pe majoritatea distribuțiilor și mediilor desktop, este \texttt{Alt+F2} folosită pentru pornirea rapidă a unei aplicații, introducând numele comenzii, la fel ca în \labelindexref{Figura}{fig:ui:app-launcher}. Funcționalitatea este numită \textit{application launcher}. Echivalentul în Windows este \texttt{Windows+r}, iar în macOS \texttt{Command+Space}.

--- a/book/chapters/02-fs/contents.tex
+++ b/book/chapters/02-fs/contents.tex
@@ -115,7 +115,6 @@ Prezentăm în continuare exemple concrete de organizare a fișierelor în siste
 În \labelindexref{Tabelul}{table:fs:linux-fs} este prezentată structura ierarhică în Linux.
 
 \begin{table}[!htb]
-\caption{Ierarhia într-un sistem de fișiere din mediul Linux}
 \begin{center}
   \begin{tabular}{ p{0.2\textwidth} p{0.7\textwidth} }
   \toprule
@@ -153,8 +152,9 @@ Prezentăm în continuare exemple concrete de organizare a fișierelor în siste
     \file{/var} & fișiere al căror conținut se schimbă foarte des, precum log-uri, fișiere temporare, cache (date reutilizabile), spool (date neprocesate)\\
   \bottomrule
   \end{tabular}
-  \label{table:fs:linux-fs}
 \end{center}
+\caption{Ierarhia într-un sistem de fișiere din mediul Linux}
+\label{table:fs:linux-fs}
 \end{table}
 
 În \labelindexref{Figura}{fig:fs:linux-fs} prezentăm cum arată grafic o ierarhie a sistemului de fișiere. Observăm că în rădăcină se află directoarele \file{home/}, \file{bin/}, \file{usr/} etc. În directorul \file{home/} se află subdirectoarele \file{ubuntu/} și \file{myuser/} ș.a.m.d.
@@ -176,7 +176,6 @@ Ierarhia sistemului de fișiere în macOS este apropiată celei din Linux.
 Structura fișierelor în Windows diferă față de cea din Linux. Aceasta este mai simplă și majoritatea directoarelor importante se află în \file{C:\textbackslash{}Windows}, așa cum se observă în \labelindexref{Tabelul}{table:fs:windows-fs}.
 
 \begin{table}[htb]
-\caption{Ierarhia într-un sistem de fișiere din Windows}
 \begin{center}
   \begin{tabular}{ p{0.32\textwidth} p{0.62\textwidth} }
   \toprule
@@ -195,8 +194,9 @@ Structura fișierelor în Windows diferă față de cea din Linux. Aceasta este 
     \file{C:\textbackslash{}Documents and Settings\textbackslash{}username\textbackslash{}My Documents} & datele unui utilizator (aceasta este calea implicită, ea poate fi modificată) \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:windows-fs}
 \end{center}
+\caption{Ierarhia într-un sistem de fișiere din Windows}
+\label{table:fs:windows-fs}
 \end{table}
 
 Deși în Linux și în macOS avem un singur director rădăcină, Windows are simultan pentru fiecare sistem de fișiere câte un director rădăcină:
@@ -212,7 +212,6 @@ Windows alocă literele în funcție de partiții, nu după sistemul de fișiere
 În \labelindexref{Tabelul}{table:fs:compare-lin-win} de mai jos avem o comparație între căile importante din sistemele de operare cele mai cunoscute.
 
 \begin{table}[htb]
-\caption{Comparație între căile sistemelor de operare}
 {\scriptsize
 \begin{center}
   \begin{tabular}{ p{0.15\textwidth} p{0.25\textwidth} p{0.25\textwidth} p{0.25\textwidth} }
@@ -228,9 +227,10 @@ Windows alocă literele în funcție de partiții, nu după sistemul de fișiere
     configurări ale sistemului & Windows Registry & directoare specifice fiecărei \ aplicații, aflate în home-ul utilizatorului; \file{/etc} & \file{/Users/username/ Library}; \file{/etc} \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:compare-lin-win}
 \end{center}
 }
+\caption{Comparație între căile sistemelor de operare}
+\label{table:fs:compare-lin-win}
 \end{table}
 
 Observăm că în Linux înșiruirea de directoare este separată de caracterul \file{/} (\textit{slash}), în timp ce în mediile Windows se folosește \file{\textbackslash{}} (\textit{backslash}).
@@ -691,7 +691,6 @@ drwxrwxr-x 2 student student 4096 sep 30 17:32 games/heroes/3/nighon/mutare
 În \labelindexref{Tabelul}{table:fs:create} sunt sumarizate comenzile de creare a tipurilor de intrări în sistemul de fișiere.
 
 \begin{table}[htb]
-\caption{Comenzi pentru crearea intrărilor în sistemul de fișere}
 \begin{center}
   \begin{tabular}{ p{0.3\textwidth} p{0.6\textwidth} }
   \toprule
@@ -704,8 +703,9 @@ drwxrwxr-x 2 student student 4096 sep 30 17:32 games/heroes/3/nighon/mutare
     legătură (link) & \cmd{ln -s \textless{}destinatie> [\textless{}nume\_legătură>]} \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:create}
 \end{center}
+\caption{Comenzi pentru crearea intrărilor în sistemul de fișere}
+\label{table:fs:create}
 \end{table}
 
 \subsection{Copiere / mutare / redenumire / ștergere}
@@ -1018,7 +1018,6 @@ Chiar dacă realizăm sincronizarea automată prin Cloud, este util să creăm �
 potrivite.
 
 \begin{table}[htb]
-\caption{Metode pentru backup}
 \begin{center}
   \begin{tabular}{ p{0.2\textwidth} p{0.7\textwidth} }
   \toprule
@@ -1035,8 +1034,9 @@ potrivite.
     rdiff-backup & Este un wrapper peste rsync. Adaugă suport pentru backupuri incrementale, adică: la un moment dat se realizează un backup complet pentru un director (asemănător rsync-ului); backup-urile incrementale salvează doar modificările ce s-au făcut de la ultimul backup pana în prezent, indiferent de tipul backup-ului; în acest fel se poate reveni la orice stare anterioara, în măsura în care s-a realizat cel puțin un backup incremental la acea stare. \\
   \bottomrule
   \end{tabular}
-  \label{table:file-system-backup-cmd}
 \end{center}
+\caption{Metode pentru backup}
+\label{table:file-system-backup-cmd}
 \end{table}
 
 Informații detaliate despre backupuri periodice folosind \cmd{rsync} vor fi prezentate în \labelindexref{Secțiunea}{sec:storage:backup:linux}.
@@ -1067,7 +1067,6 @@ Restul fișierelor deschise de aplicații au un descriptor de fișier mai mare s
 În unele situații, utilizatorul poate dori să modifice intrarea sau ieșirea pentru o aplicație. De exemplu, utilizatorul își poate dori ca în loc să obțină datele de intrare de la tastatură pentru un program, să le obțină dintr-un fișier. Aceste operații se pot realiza doar la nivelul descriptorilor. În shell sunt permise comenzi cu o sintaxă specială asupra descriptorilor standard modificați; pot fi întâlnite cazurile de redirectare din \labelindexref{Tabelul}{table:fs:redirect}.
 
 \begin{table}[htb]
-\caption{Metode de redirectare}
 \begin{center}
   \begin{tabular}{ p{0.2\textwidth} p{0.2\textwidth} p{0.5\textwidth}}
   \toprule
@@ -1084,8 +1083,9 @@ Restul fișierelor deschise de aplicații au un descriptor de fișier mai mare s
     eroare \& ieșire & Fișier & \cmd{./program $>$ fișier\_ieșire\_și\_erori 2$>$\&1} \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:redirect}
 \end{center}
+\caption{Metode de redirectare}
+\label{table:fs:redirect}
 \end{table}
 
 Pentru a redirecta ieșirea (către exteriorul programului) se folosește caracterul \texttt{$>$} (semnul \textit{mai mare}), în timp ce pentru a redirecta intrarea se folosește caracterul \texttt{$<$} (semnul \textit{mai mic}) (către program), iar pentru redirectarea ieșirii de erori se folosește descriptorul \texttt{2} de fișier urmat de caracterul \texttt{$>$}.
@@ -1158,7 +1158,6 @@ fstat(3, {st_mode=S_IFREG|0644, st_size=91329, ...}) = 0
 \labelindexref{Tabelul}{table:file-system-redirect-special} prezintă câteva redirectări folosind fișiere speciale.
 
 \begin{table}[htb]
-\caption{Redirectări folosind fișiere speciale}
   {\scriptsize
 \begin{center}
   \begin{tabular}{ p{0.4\textwidth} p{0.5\textwidth}}
@@ -1174,9 +1173,10 @@ fstat(3, {st_mode=S_IFREG|0644, st_size=91329, ...}) = 0
     \cmd{cat /dev/null $>$ new\_file} & creează un fișier cu același conținut ca \file{/dev/null}, adică un fișier gol, indentic ca mai sus \\
   \bottomrule
   \end{tabular}
-  \label{table:file-system-redirect-special}
 \end{center}
   }
+\caption{Redirectări folosind fișiere speciale}
+\label{table:file-system-redirect-special}
 \end{table}
 
 Detalii despre internele redirectării și ce se întâmplă la nivelul unei aplicații găsiți în \labelindexref{Secțiunea}{sec:process:redirect}.
@@ -1189,7 +1189,6 @@ Detalii despre internele redirectării și ce se întâmplă la nivelul unei apl
 Pentru mai multe informații despre crearea, montarea și repararea unui sistem de fișiere, precum și lucrul cu partiții, citiți \labelindexref{Capitolul}{chapter:storage}. În \labelindexref{Tabelul}{table:fs:os-fs} de mai jos se găsesc unele dintre cele mai importante sisteme de fișiere utilizate în prezent, alături de sistemele de operare în care operează.
 
 \begin{table}[htb]
-\caption{Sisteme de operare și sisteme de fișiere}
 \begin{center}
   \begin{tabular}{ p{0.18\textwidth} p{0.23\textwidth} p{0.23\textwidth} p{0.23\textwidth} }
   \toprule
@@ -1211,8 +1210,9 @@ Pentru mai multe informații despre crearea, montarea și repararea unui sistem 
     UDF & Nativ & Nativ & Nativ \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:os-fs}
 \end{center}
+\caption{Sisteme de operare și sisteme de fișiere}
+\label{table:fs:os-fs}
 \end{table}
 
 Termenul ,,nativ'' semnifică faptul că suportul este oferit de driverele ce însoțesc sistemul de operare.
@@ -1220,7 +1220,6 @@ Termenul ,,nativ'' semnifică faptul că suportul este oferit de driverele ce î
 Sistemele de fișiere pot fi clasificate după locul în care datele sunt stocate. \labelindexref{Tabelul}{table:fs:fs-storage} prezintă succint această clasificare.
 
 \begin{table}[htb]
-\caption{Clasificarea sistemelor de fișiere după suportul datelor}
 \begin{center}
   \begin{tabular}{ p{0.25\textwidth} p{0.25\textwidth} p{0.4\textwidth} }
   \toprule
@@ -1233,8 +1232,9 @@ Sistemele de fișiere pot fi clasificate după locul în care datele sunt stocat
     sisteme de fișiere pentru rețea & NFS, SMB & utilizate pentru accesul la fișiere aflate în rețea \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:fs-storage}
 \end{center}
+\caption{Clasificarea sistemelor de fișiere după suportul datelor}
+\label{table:fs:fs-storage}
 \end{table}
 
 Sistemele de fișiere virtuale (precum \texttt{procfs}) sunt sisteme care nu au suport fizic pe disc. Accesul prin comenzi la aceste sisteme de fișiere duce de obicei la date care se găsesc în memorie. Despre sistemul de fișiere \texttt{procfs} vor fi prezentate detalii în \labelindexref{Secțiunea}{sec:process:proc}.
@@ -1265,9 +1265,9 @@ Atunci când alegem un sistem de fișiere, criteriile cele mai căutate sunt:
 \labelindexref{Tabelul}{table:fs:details} realizează o analiză sumară a caracteristicilor sistemelor de fișiere. Unitatea TiB reprezintă un tebibyte, adică $2^{40}$ octeți, iar un EiB reprezintă un exbibyte, adică $2^{60}$ octeți.
 
 \begin{table}[htb]
-\caption{Caracteristici ale sistemelor de fișiere mai cunoscute}
+  \scriptsize
 \begin{center}
-  \begin{tabular}{ p{0.1\textwidth} p{0.15\textwidth} p{0.2\textwidth} p{0.15\textwidth} p{0.35\textwidth} }
+  \begin{tabular}{ p{0.07\textwidth} p{0.15\textwidth} p{0.2\textwidth} p{0.07\textwidth} p{0.35\textwidth} }
   \toprule
     \textbf{Nume} & \textbf{Sisteme de operare} &
     \textbf{Dimensiune maximă fișier} & \textbf{Jurnalizare} &
@@ -1281,7 +1281,7 @@ Atunci când alegem un sistem de fișiere, criteriile cele mai căutate sunt:
   \midrule
     Ext4 & Linux / Windows / MacOS & 16TiB & da & Succesorul lui Ext3, îmbunătățind performanța, stabilitatea și capacitatea de stocare. Este adecvat și pentru stocarea datelor critice, datorită preciziei ridicate ale marcajelor temporale. \\
   \midrule
-    HFS+ & Mac OS / Linux & 16 EiB & da* & * în Linux, HFS+ este suportat fără jurnalizare \\
+    HFS+ & Mac OS / Linux & 16 EiB & da* & * în Linux, HFS+ are suport fără jurnalizare \\
   \midrule
     APFS & MacOS, iOS & 8 EiB & da & Este optimizat pentru dispozitivele de stocare tip flash și solid drive, și pune accentul pe criptare. \\
   \midrule
@@ -1290,8 +1290,9 @@ Atunci când alegem un sistem de fișiere, criteriile cele mai căutate sunt:
     UDF & Win / Linux / Mac OS & 16 EiB & da & Sistem de fișiere utilizat în principal pe mediile optice, cu suport atât pentru scriere cât și pentru citire \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:details}
 \end{center}
+\caption{Caracteristici ale sistemelor de fișiere mai cunoscute}
+\label{table:fs:details}
 \end{table}
 
 \section{Anexă: Comenzi pentru lucrul cu fișiere în Windows}
@@ -1300,7 +1301,6 @@ Atunci când alegem un sistem de fișiere, criteriile cele mai căutate sunt:
 \labelindexref{Tabelul}{table:fs:compare-lin-win-cmd} prezintă comenzile echivalente în Windows pentru operațiile de lucru cu sistemul de fișiere. Acestea pot fi folosite în prompt-urile Windows precum PowerShell sau Command Prompt.
 
 \begin{table}[htb]
-\caption{Echivalențe comenzi Linux și Windows}
 \begin{center}
   \begin{tabular}{ p{0.2\textwidth} p{0.2\textwidth} p{0.4\textwidth} }
   \toprule
@@ -1343,8 +1343,9 @@ Atunci când alegem un sistem de fișiere, criteriile cele mai căutate sunt:
     \cmd{diff} & \cmd{fc} & afișează diferențele dintre două fișiere \\
   \bottomrule
   \end{tabular}
-  \label{table:fs:compare-lin-win-cmd}
 \end{center}
+\caption{Echivalențe comenzi Linux și Windows}
+\label{table:fs:compare-lin-win-cmd}
 \end{table}
 
 \section{Sumar}

--- a/book/chapters/03-package/contents.tex
+++ b/book/chapters/03-package/contents.tex
@@ -121,7 +121,6 @@ Noțiunea de manager de pachete este răspândită îndeosebi în distribuții L
 \labelindexref{Tabelul}{tab:package:types} conține cele mai cunoscute tipuri de managere de pachete cu tipurile de pachete și distribuțiile pe care le folosesc, împreună cu aplicațiile și comenzile specifice.
 
 \begin{table}[!htb]
-  \caption{Managere și tipuri de pachete}
   \scriptsize
   \begin{center}
     \begin{tabular}{ p{0.2\textwidth} p{0.15\textwidth} p{0.27\textwidth} p{0.23\textwidth} }
@@ -178,8 +177,9 @@ Noțiunea de manager de pachete este răspândită îndeosebi în distribuții L
 
       \bottomrule
     \end{tabular}
-    \label{tab:package:types}
   \end{center}
+  \caption{Managere și tipuri de pachete}
+  \label{tab:package:types}
 \end{table}
 
 \subsection{Operații cu pachete}
@@ -378,7 +378,6 @@ Sunt prezente următoarele tabele:
 \end{itemize}
 
 \begin{table}[!htb]
-  \caption{Configurare repository}
   \scriptsize
   \begin{center}
     \begin{tabular}{ p{0.15\textwidth} p{0.4\textwidth} p{0.25\textwidth} }
@@ -424,12 +423,12 @@ Sunt prezente următoarele tabele:
         \cmd{choco} \\
       \bottomrule
     \end{tabular}
-    \label{tab:package:config-repository}
   \end{center}
+  \caption{Configurare repository}
+  \label{tab:package:config-repository}
 \end{table}
 
 \begin{table}[!htb]
-  \caption{Actualizare / Upgrade}
   \scriptsize
   \begin{center}
     \begin{tabular}{ p{0.15\textwidth} p{0.3\textwidth} p{0.33\textwidth} }
@@ -475,12 +474,12 @@ Sunt prezente următoarele tabele:
         \cmd{choco upgrade all} \\
       \bottomrule
     \end{tabular}
-    \label{tab:package:config-update}
   \end{center}
+  \caption{Actualizare / Upgrade}
+  \label{tab:package:config-update}
 \end{table}
 
 \begin{table}[!htb]
-  \caption{Instalare / Dezinstalare}
   \scriptsize
   \begin{center}
     \begin{tabular}{ p{0.15\textwidth} p{0.25\textwidth} p{0.2\textwidth} p{0.2\textwidth} }
@@ -536,12 +535,12 @@ Sunt prezente următoarele tabele:
         \cmd{choco uninstall hello} \\
       \bottomrule
     \end{tabular}
-    \label{tab:package:config-install}
   \end{center}
+  \caption{Instalare / Dezinstalare}
+  \label{tab:package:config-install}
 \end{table}
 
 \begin{table}[!htb]
-  \caption{Descărcare pachet / sursă}
   \scriptsize
   \begin{center}
     \begin{tabular}{ p{0.15\textwidth} p{0.4\textwidth} p{0.35\textwidth} }
@@ -587,12 +586,12 @@ Sunt prezente următoarele tabele:
         N/A \\
       \bottomrule
     \end{tabular}
-    \label{tab:package:config-download}
   \end{center}
+  \caption{Descărcare pachet / sursă}
+  \label{tab:package:config-download}
 \end{table}
 
 \begin{table}[!htb]
-  \caption{Căutare / Listare}
   \scriptsize
   \begin{center}
     \begin{tabular}{ p{0.15\textwidth} p{0.2\textwidth} p{0.2\textwidth} p{0.2\textwidth} }
@@ -648,8 +647,9 @@ Sunt prezente următoarele tabele:
         N/A \\
       \bottomrule
     \end{tabular}
-    \label{tab:package:config-list}
   \end{center}
+  \caption{Căutare / Listare}
+  \label{tab:package:config-list}
 \end{table}
 
 \section{Sisteme de distribuție cu tot cu sistem}

--- a/book/chapters/04-process/contents.tex
+++ b/book/chapters/04-process/contents.tex
@@ -261,7 +261,6 @@ atribute de bază ale unui proces împreună cu o descriere a lor se găsește �
 \labelindexref{Tabelul}{tab:process:attributes}.
 
 \begin{table}[!htb]
-\caption{Atributele unui proces}
 \begin{center}
   \begin{tabular}{ p{0.20\textwidth} p{0.40\textwidth} p{0.15\textwidth} p{0.10\textwidth}  }
 	\toprule
@@ -290,8 +289,9 @@ atribute de bază ale unui proces împreună cu o descriere a lor se găsește �
                 spațiu virtual de adrese & harta memoriei unui proces & pornire & da \\
 	\bottomrule
 	\end{tabular}
-        \label{tab:process:attributes}
 \end{center}
+\caption{Atributele unui proces}
+\label{tab:process:attributes}
 \end{table}
 
 Atributul PID este identificatorul unic al procesului la nivelul sistemului de
@@ -1811,7 +1811,6 @@ recomandăm în defavoarea \cmd{screen}. De avut în vedere că multe opțiuni p
 
 \begin{table}[!htb]
 \scriptsize
-\caption{Comparație de comenzi de multiplexor de terminal}
 \begin{center}
 	\begin{tabular}{ p{0.20\textwidth} p{0.23\textwidth} p{0.23\textwidth} p{0.23\textwidth} }
 	\toprule
@@ -1830,8 +1829,9 @@ recomandăm în defavoarea \cmd{screen}. De avut în vedere că multe opțiuni p
           închidere sesiune & \texttt{Ctrl+b :kill-session} & \texttt{Ctrl+a \textbackslash{}} & \texttt{Ctrl+a \textbackslash{}} \\
 	\bottomrule
 	\end{tabular}
-        \label{tab:process:tmux-screen-byobu}
 \end{center}
+\caption{Comparație de comenzi de multiplexor de terminal}
+\label{tab:process:tmux-screen-byobu}
 \end{table}
 
 Dacă ne interesează strict rularea unei sesiuni de terminal, nu și partea de

--- a/book/chapters/05-user/contents.tex
+++ b/book/chapters/05-user/contents.tex
@@ -569,7 +569,6 @@ configurare în care sunt reținute informații despre utilizatori sunt indicate
 \labelindexref{Tabelul}{table:user:info-files}.
 
 \begin{table}[!htb]
-\caption{Informații despre utilizatori}
 \begin{center}
   \begin{tabular}{ p{0.18\textwidth} p{0.22\textwidth} p{0.55\textwidth} }
 	\toprule
@@ -582,8 +581,9 @@ configurare în care sunt reținute informații despre utilizatori sunt indicate
                 \file{/etc/group} & informații grupuri & nume grup, GID, utilizatori aferenți \\
 	\bottomrule
 	\end{tabular}
-        \label{table:user:info-files}
 \end{center}
+\caption{Informații despre utilizatori}
+\label{table:user:info-files}
 \end{table}
 
 Fișierele de configurare au formă tabelară cu coloane: fiecare linie este o
@@ -616,7 +616,6 @@ Altfel, informații despre utilizatori obținem folosind utilitare precum cele d
 \labelindexref{Tabelul}{table:user:tools-files}. Aceste utilitare investighează fișierele de configurare din \labelindexref{Tabelul}{table:user:info-files}.
 
 \begin{table}[!htb]
-\caption{Utilitare de investigare utilizatori}
 \begin{center}
   \begin{tabular}{ p{0.20\textwidth} p{0.35\textwidth} p{0.35\textwidth} }
 	\toprule
@@ -633,8 +632,9 @@ Altfel, informații despre utilizatori obținem folosind utilitare precum cele d
                 \cmd{finger}, \cmd{pinky} & informații complete despre un utilizator & \file{/etc/passwd}, \file{/etc/group} \\
 	\bottomrule
 	\end{tabular}
-        \label{table:user:tools-files}
 \end{center}
+\caption{Utilitare de investigare utilizatori}
+\label{table:user:tools-files}
 \end{table}
 
 În \labelindexref{Listing}{lst:user:commands} sunt câteva exemple de folosire ale comenzilor de mai sus.
@@ -749,7 +749,6 @@ mediul desktop folosit (GNOME, KDE, XFCE etc.) În mod tradițional, gestiunea s
 face în linia de comandă cu ajutorul utilitarelor specifice, indicate în \labelindexref{Tabelul}{table:user:tools-manage}.
 
 \begin{table}[!htb]
-\caption{Utilitare de gestiune a utilizatorilor}
 \begin{center}
   \begin{tabular}{ p{0.30\textwidth} p{0.20\textwidth} p{0.35\textwidth} }
 	\toprule
@@ -774,8 +773,9 @@ face în linia de comandă cu ajutorul utilitarelor specifice, indicate în \lab
                 schimbare parolă & \cmd{passwd} & \file{/etc/shadow} \\
 	\bottomrule
 	\end{tabular}
-        \label{table:user:tools-manage}
 \end{center}
+\caption{Utilitare de gestiune a utilizatorilor}
+\label{table:user:tools-manage}
 \end{table}
 
 Pe distribuțiile bazate pe Debian (Debian, Ubuntu, Linux Mint etc.) există un
@@ -783,7 +783,6 @@ set de utilitare mai ușor de folosit care înglobează comenzile de mai sus,
 indicate în \labelindexref{Tabelul}{table:user:debian-wrapper}
 
 \begin{table}[!htb]
-\caption{Utilitare wrapper Debian}
 \begin{center}
   \begin{tabular}{ p{0.40\textwidth} p{0.40\textwidth} }
 	\toprule
@@ -798,8 +797,9 @@ indicate în \labelindexref{Tabelul}{table:user:debian-wrapper}
                 \cmd{delgroup} & \cmd{groupdel} \\
 	\bottomrule
 	\end{tabular}
-        \label{table:user:debian-wrapper}
 \end{center}
+\caption{Utilitare wrapper Debian}
+\label{table:user:debian-wrapper}
 \end{table}
 
 În Linux/Unix există două tipuri de grupuri: \textbf{grupuri primare} și \textbf{grupuri secundare}. Un utilizator
@@ -813,7 +813,6 @@ informații proprii: shellul de login, numele de utilizator, datele personale,
 parola. Pentru aceasta folosește utilitarele din \labelindexref{Tabelul}{table:user:self-manage}.
 
 \begin{table}[!htb]
-\caption{Utilitare pentru modificare informații proprii}
 \begin{center}
   \begin{tabular}{ p{0.40\textwidth} p{0.40\textwidth} }
 	\toprule
@@ -826,8 +825,9 @@ parola. Pentru aceasta folosește utilitarele din \labelindexref{Tabelul}{table:
                 schimbare parolă & \cmd{passwd} \\
 	\bottomrule
 	\end{tabular}
-        \label{table:user:self-manage}
 \end{center}
+\caption{Utilitare pentru modificare informații proprii}
+\label{table:user:self-manage}
 \end{table}
 
 Un grup care este grupul primar al unui utilizator nu poate fi șters. Întâi trebuie să fie șters utilizatorul, apoi grupul.
@@ -1486,7 +1486,6 @@ este cazul acestea trebuie acordate explicit.
 Exemple sunt prezente în \labelindexref{Tabelul}{table:user:umask}.
 
 \begin{table}[!htb]
-\caption{Permisiuni de creare fișier în funcție de mască}
 \begin{center}
   \begin{tabular}{ p{0.20\textwidth} p{0.20\textwidth} p{0.20\textwidth} p{0.20\textwidth} }
 	\toprule
@@ -1499,8 +1498,9 @@ Exemple sunt prezente în \labelindexref{Tabelul}{table:user:umask}.
                 \texttt{077} & \texttt{700} & \texttt{600} & \texttt{700} \\
 	\bottomrule
 	\end{tabular}
-        \label{table:user:umask}
 \end{center}
+\caption{Permisiuni de creare fișier în funcție de mască}
+\label{table:user:umask}
 \end{table}
 
 Afișarea și modificarea măștii shellului se face folosind comanda \cmd{umask}. Fără

--- a/book/chapters/07-cli/contents.tex
+++ b/book/chapters/07-cli/contents.tex
@@ -174,7 +174,6 @@ shell. Aceste combinații de taste au două avantaje:
 \labelindexref{Tabelul}{tab:cli:key-bindings} prezintă cele mai comune astfel de combinații de taste și efectul lor.
 
 \begin{table}[!htb]
-  \caption{Combinații de taste în shell}
   \begin{center}
     \begin{tabular}{ p{0.20\textwidth} p{0.70\textwidth} }
       \toprule
@@ -221,8 +220,9 @@ shell. Aceste combinații de taste au două avantaje:
         ștergerea cuvântului din spatele cursorului \\
       \bottomrule
     \end{tabular}
-    \label{tab:cli:key-bindings}
   \end{center}
+  \caption{Combinații de taste în shell}
+  \label{tab:cli:key-bindings}
 \end{table}
 
 Combinațiile de taste \texttt{Ctrl+c} și \texttt{Ctrl+\textbackslash{}} sunt folosite pentru a opri procesul curent, prin transmiterea semnalului, respectiv, \texttt{SIGINT} și \texttt{SIGQUIT}, așa cum am precizat în \label{sec:process:signal}.
@@ -418,7 +418,6 @@ fi nevoie de modificarea shellului, cum ar fi cazul comenzilor interne.
 externe.
 
 \begin{table}[!htb]
-  \caption{Combinații de taste în shell}
   \begin{center}
     \begin{tabular}{ p{0.25\textwidth} p{0.3\textwidth} p{0.3\textwidth} }
       \toprule
@@ -443,8 +442,9 @@ externe.
         nu \\
       \bottomrule
     \end{tabular}
-    \label{tab:cli:internal-vs-external}
   \end{center}
+  \caption{Combinații de taste în shell}
+  \label{tab:cli:internal-vs-external}
 \end{table}
 
 Pentru a identifica rapid tipul unei comenzi, se poate folosi comanda \cmd{which}

--- a/book/chapters/09-boot/contents.tex
+++ b/book/chapters/09-boot/contents.tex
@@ -241,7 +241,6 @@ de firmware (numite imagini EFI) care rețin codul bootloaderului ce va fi
 \labelindexref{Tabelul}{tab:boot:bios-uefi} prezintă principalele deosebiri\footnote{\url{https://www.freecodecamp.org/news/uefi-vs-bios/}} între BIOS și UEFI:
 
 \begin{table}[!htb]
-  \caption{Comparație BIOS-UEFI}
   \begin{center}
     \begin{tabular}{ p{0.40\textwidth} p{0.25\textwidth} p{0.25\textwidth} }
       \toprule
@@ -271,8 +270,9 @@ de firmware (numite imagini EFI) care rețin codul bootloaderului ce va fi
 
       \bottomrule
     \end{tabular}
-    \label{tab:boot:bios-uefi}
   \end{center}
+  \caption{Comparație BIOS-UEFI}
+  \label{tab:boot:bios-uefi}
 \end{table}
 
 Datorită flexibilității, sistemele PC \abbrev{PC}{Personal Computer} moderne

--- a/book/chapters/11-net/contents.tex
+++ b/book/chapters/11-net/contents.tex
@@ -90,7 +90,6 @@ Dezvoltarea a Internetului duce la o diversificare continuă: apar tipuri noi, a
 
 \begin{table}[!htb]
   {\scriptsize
-  \caption{Tipuri de servicii de Internet}
   \begin{center}
     \begin{tabular}{ p{0.35\textwidth} p{0.57\textwidth} }
       \toprule
@@ -133,9 +132,10 @@ Dezvoltarea a Internetului duce la o diversificare continuă: apar tipuri noi, a
         GitHub, Microsoft SharePoint, Google Drive, Trello \\
       \bottomrule
     \end{tabular}
-    \label{tab:net:services}
   \end{center}
   }
+  \caption{Tipuri de servicii de Internet}
+  \label{tab:net:services}
 \end{table}
 
 Așa cum este precizat în \labelindexref{Figura}{fig:net:internet-amazon-service}, accesarea unui serviciu din Internet se realizează prin intermediul unei aplicații client de pe un sistem client al unui utilizator.
@@ -311,7 +311,6 @@ Informația digitală este transmisă sub formă de semnal în funcție de mediu
 
 \begin{table}[!htb]
   {\scriptsize
-  \caption{Medii de transmisie}
   \begin{center}
     \begin{tabular}{ p{0.15\textwidth} p{0.15\textwidth} p{0.10\textwidth} p{0.25\textwidth} p{0.2\textwidth} }
       \toprule
@@ -342,9 +341,10 @@ Informația digitală este transmisă sub formă de semnal în funcție de mediu
         cost mare \\
       \bottomrule
     \end{tabular}
-    \label{tab:net:media}
   \end{center}
   }
+  \caption{Medii de transmisie}
+  \label{tab:net:media}
 \end{table}
 
 O stație comunică printr-un mediu de transmisie cu un echipament de rețea: prin aer cu un access point, prin cablu sau fibră optică cu un switch sau un ruter.

--- a/book/chapters/13-auto/contents.tex
+++ b/book/chapters/13-auto/contents.tex
@@ -446,7 +446,6 @@ Diferență constă în escaparea celor două construcții prin ghilimele.
 Astfel, construcția \texttt{\$*} se va expanda la o singură valoare care conține spații între parametrii scriptului, în vreme ce construcția \texttt{\$@} se va expanda la o listă de valori escapate fiecare prin ghilimele.
 
 \begin{table}[!htb]
-  \caption{Construcții pentru parametrii unui script shell}
   \begin{center}
     \begin{tabular}{ p{0.25\textwidth} p{0.65\textwidth} }
       \toprule
@@ -470,8 +469,9 @@ Astfel, construcția \texttt{\$*} se va expanda la o singură valoare care conț
 
       \bottomrule
     \end{tabular}
-    \label{tab:auto:script-params}
   \end{center}
+  \caption{Construcții pentru parametrii unui script shell}
+  \label{tab:auto:script-params}
 \end{table}
 
 În lucrul cu parametrii, shellul oferă comanda \cmd{shift}.
@@ -555,7 +555,6 @@ Condiția poate fi comparație între numere, între șiruri de caractere, verif
 O listă completă găsiți în pagina de manual a comenzii \cmd{test}.
 
 \begin{table}[!htb]
-  \caption{Condiții folosite de comanda test}
   \begin{center}
     \renewcommand*\arraystretch{1.3}  % Altfel liniile tabelului sunt imposibil de diferențiat.
     \begin{tabular}{ p{0.5\textwidth} p{0.45\textwidth} }
@@ -592,8 +591,9 @@ O listă completă găsiți în pagina de manual a comenzii \cmd{test}.
 
       \bottomrule
     \end{tabular}
-    \label{tab:auto:test}
   \end{center}
+  \caption{Condiții folosite de comanda test}
+  \label{tab:auto:test}
 \end{table}
 
 Comanda \cmd{test} are ca echivalent comanda \cmd{$[$} (paranteză dreaptă deschisă).


### PR DESCRIPTION
This makes tables consistent with figures and listings where captions are also below.
This commit addresses issue #16.